### PR TITLE
Fixed positionItem() to position correctly when scrolled

### DIFF
--- a/wui-1-2-1/js/wui.js
+++ b/wui-1-2-1/js/wui.js
@@ -238,6 +238,7 @@ Wui.positionItem = function(parent,child){
 
     // If we we are not in a dialog window then add the scrollTop in case they have scrolled down.
     if(win.length == 0){
+        top += $(window).scrollTop();
     }
 		
     child.css({

--- a/wui-1-2-1/js/wui.js
+++ b/wui-1-2-1/js/wui.js
@@ -207,6 +207,7 @@ Wui.percentToPixels = function(el,percent,dim){
 
 
 Wui.positionItem = function(parent,child){
+	var win = $(parent).closest('.w121-window');
     var ofst    =   parent[0].getBoundingClientRect(),
         top     =   ofst.top,
         fxdOrAbs =  (function(){
@@ -235,6 +236,10 @@ Wui.positionItem = function(parent,child){
                     })(),
         plRight =   (ofst.left + parent.outerWidth() - cWidth > 0);
 
+    // If we we are not in a dialog window then add the scrollTop in case they have scrolled down.
+    if(win.length == 0){
+    }
+		
     child.css({
         left:       (plRight) ? ofst.left + parent.outerWidth() - cWidth : ofst.left,
         top:        (plBelow) ? top + parent.outerHeight() : top - ($.isNumeric(cHeight) ? cHeight : child.outerHeight()),


### PR DESCRIPTION
This is a change to the wui.positionItem() method. When you scroll on the main window and click on a dropdown combo the combo list would be positioned incorrectly. So we needed to add the "scrollTop()" to position it correctly. Another complication is that when the combo is within a wui.Window it must not have the scrollTop added to it because parent[0].getBoundingClientRect().top gives the offset from the top of the viewport which works correctly when you are in the dialog.